### PR TITLE
Different decay for logs

### DIFF
--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -2,6 +2,7 @@ package edu.cuny.hunter.log.core.analysis;
 
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -483,13 +484,20 @@ public class LogAnalyzer extends ASTVisitor {
 	}
 
 	public void collectDOIValues(HashSet<MethodDeclaration> methods) {
+		Set<IMethod> enclosingMethods = getEnclosingMethods();
+
 		methods.forEach(m -> {
 			IMethodBinding methodBinding = m.resolveBinding();
 			if (methodBinding != null) {
-				IDegreeOfInterest degreeOfInterest = Util.getDegreeOfInterest((IMethod) methodBinding.getJavaElement());
-				this.DOIValues.add(Util.getDOIValue(degreeOfInterest));
+				float doiValue = Util.getDOIValue((IMethod) methodBinding.getJavaElement(), enclosingMethods);
+				this.DOIValues.add(doiValue);
 			}
 		});
+	}
+
+	private Set<IMethod> getEnclosingMethods() {
+		return this.getLogInvocationSet().parallelStream().map(LogInvocation::getEnclosingEclipseMethod)
+				.filter(Objects::nonNull).collect(Collectors.toSet());
 	}
 
 	/**

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -38,7 +38,8 @@ public class LogAnalyzer extends ASTVisitor {
 	private HashSet<LogInvocation> logInvsNotTransformedInIf = new HashSet<LogInvocation>();
 
 	/**
-	 * Set of log invocations that their log levels are not lower in catch blocks
+	 * Set of log invocations that their log levels are not lower in catch
+	 * blocks
 	 */
 	private HashSet<LogInvocation> logInvsNotLoweredInCatch = new HashSet<LogInvocation>();
 
@@ -70,7 +71,9 @@ public class LogAnalyzer extends ASTVisitor {
 	 * A set of keywords in log messages.
 	 */
 	private final Set<String> KEYWORDS_IN_LOG_MESSAGES = Stream.of("fail", "disable", "error", "exception", "collision",
-			"reboot", "terminate", "throw", "should", "start", "should", "tried", "empty", "launch", "init", "does not", "doesn't", "stop", "shut", "run", "deprecate", "kill", "finish", "ready", "wait").collect(Collectors.toSet());
+			"reboot", "terminate", "throw", "should", "start", "should", "tried", "empty", "launch", "init", "does not",
+			"doesn't", "stop", "shut", "run", "deprecate", "kill", "finish", "ready", "wait")
+			.collect(Collectors.toSet());
 
 	private boolean test;
 
@@ -164,8 +167,8 @@ public class LogAnalyzer extends ASTVisitor {
 		}
 
 		/**
-		 * Do not change a log level in a logging statement if there exists an immediate
-		 * if statement whose condition contains a log level.
+		 * Do not change a log level in a logging statement if there exists an
+		 * immediate if statement whose condition contains a log level.
 		 */
 		if (this.checkIfCondition) {
 			if (checkIfConditionHavingLevel(logInvocation.getExpression())) {
@@ -295,8 +298,8 @@ public class LogAnalyzer extends ASTVisitor {
 	}
 
 	/**
-	 * Build a list of boundary. The DOI values could be divided into 7 groups by
-	 * this boundary. 7 groups are corresponding to 7 logging levels
+	 * Build a list of boundary. The DOI values could be divided into 7 groups
+	 * by this boundary. 7 groups are corresponding to 7 logging levels
 	 * 
 	 * @param degreeOfInterests
 	 * @return a list of boundary
@@ -415,9 +418,9 @@ public class LogAnalyzer extends ASTVisitor {
 	}
 
 	/**
-	 * Returns true if the given logging expression is immediately contained within
-	 * an if statement not having an else clause (i.e., guarded) and false
-	 * otherwise.
+	 * Returns true if the given logging expression is immediately contained
+	 * within an if statement not having an else clause (i.e., guarded) and
+	 * false otherwise.
 	 */
 	private static boolean checkIfBlock(MethodInvocation loggingExpression) {
 		ASTNode loggingStatement = loggingExpression.getParent();

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
@@ -1,5 +1,6 @@
 package edu.cuny.hunter.log.core.analysis;
 
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -324,8 +325,8 @@ public class LogInvocation {
 	 * Should update DOI values after evaluating git history.
 	 */
 	public void updateDOI() {
-		this.degreeOfInterest = Util.getDegreeOfInterest(this.getEnclosingEclipseMethod());
-		this.degreeOfInterestValue = Util.getDOIValue(this.degreeOfInterest);
+		this.degreeOfInterestValue = Util.getDOIValue(this.getEnclosingEclipseMethod(),
+				Collections.singleton(this.getEnclosingEclipseMethod()));
 	}
 
 	public Name getReplacedName() {

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/refactorings/LogRejuvenatingProcessor.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/refactorings/LogRejuvenatingProcessor.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -17,6 +19,7 @@ import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
@@ -116,12 +119,14 @@ public class LogRejuvenatingProcessor extends RefactoringProcessor {
 	 */
 	private boolean isEvaluation;
 
-	private HashSet<LogInvocation> logInvsNotTransformedInIf = new HashSet<LogInvocation>();
-	private HashSet<LogInvocation> logInvsNotLoweredInCatch = new HashSet<LogInvocation>();
-	private HashSet<LogInvocation> logInvsNotLoweredInIf = new HashSet<LogInvocation>();
-	private HashSet<LogInvocation> logInvsNotLoweredWithKeywords = new HashSet<LogInvocation>();
+	private HashSet<LogInvocation> logInvsNotTransformedInIf;
+	private HashSet<LogInvocation> logInvsNotLoweredInCatch;
+	private HashSet<LogInvocation> logInvsNotLoweredInIf;
+	private HashSet<LogInvocation> logInvsNotLoweredWithKeywords;
+	private Map<IMethod, Float> methodToDOI;
+	private Set<IMethod> enclosingMethods;
 
-	private String repoURL = "";
+	private String repoURL;
 
 	public LogRejuvenatingProcessor(final CodeGenerationSettings settings) {
 		super(settings);
@@ -278,6 +283,8 @@ public class LogRejuvenatingProcessor extends RefactoringProcessor {
 			this.setLogInvsNotTransformedInIf(analyzer.getLogInvsNotTransformedInIf());
 			this.setLogInvsNotLoweredInIf(analyzer.getLogInvsNotLoweredInIfStatement());
 			this.setLogInvsNotLoweredWithKeywords(analyzer.getLogInvsNotLoweredByKeywords());
+			this.setMethodToDOI(analyzer.getMethodToDOI());
+			this.setEnclosingMethods(analyzer.getEnclosingMethods());
 
 			// Get boundary
 			this.boundary = analyzer.getBoundary();
@@ -532,4 +539,16 @@ public class LogRejuvenatingProcessor extends RefactoringProcessor {
 		this.logInvsNotLoweredWithKeywords = logInvsNotLoweredWithKeywords;
 	}
 
+	private void setMethodToDOI(Map<IMethod, Float> methodToDOI) {
+		this.methodToDOI = methodToDOI;
+	}
+
+	private void setEnclosingMethods(Set<IMethod> enclosingMethods) {
+		this.enclosingMethods = enclosingMethods;
+	}
+
+	public Map<IMethod, Float> getNonenclosingMethodToDOI() {
+		return this.methodToDOI.keySet().stream().filter(m -> !this.enclosingMethods.contains(m))
+				.collect(Collectors.toMap(Function.identity(), m -> this.methodToDOI.get(m)));
+	}
 }

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
@@ -126,10 +126,10 @@ public final class Util {
 	}
 
 	/**
-	 * We only focus on the logging level, which is set by the developer. Hence, we
-	 * do not record the logging level which is embedded by the logging package.
-	 * e.g. each time we call method entering, a logging record which has "FINER"
-	 * level is created.
+	 * We only focus on the logging level, which is set by the developer. Hence,
+	 * we do not record the logging level which is embedded by the logging
+	 * package. e.g. each time we call method entering, a logging record which
+	 * has "FINER" level is created.
 	 * 
 	 * @param node
 	 * @return logging level

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
@@ -25,12 +25,18 @@ import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
 import org.eclipse.mylyn.context.core.ContextCore;
 import org.eclipse.mylyn.context.core.IDegreeOfInterest;
 import org.eclipse.mylyn.context.core.IInteractionElement;
+import org.eclipse.mylyn.internal.context.core.InteractionContextScaling;
+
 import edu.cuny.hunter.log.core.refactorings.LogRejuvenatingProcessor;
 import edu.cuny.hunter.mylyngit.core.analysis.MylynGitPredictionProvider;
 import edu.cuny.hunter.mylyngit.core.utils.NonActiveMylynTaskException;
 
 @SuppressWarnings("restriction")
 public final class Util {
+	private static final int ENCLOSING_METHOD_DECAY_FACTOR = 32;
+	
+	private static Float originalDecay;
+
 	public static ProcessorBasedRefactoring createRejuvenating(IJavaProject[] projects,
 			Optional<IProgressMonitor> monitor) throws JavaModelException {
 		LogRejuvenatingProcessor processor = createLoggingProcessor(projects, monitor);
@@ -62,24 +68,36 @@ public final class Util {
 	/**
 	 * Get DOI value.
 	 */
-	public static float getDOIValue(IDegreeOfInterest degreeOfInterest) {
+	public static float getDOIValue(IMethod method, Set<IMethod> enclosingMethods) {
+		IInteractionElement interactionElement = getInteractionElement(method);
+
+		if (interactionElement == null || interactionElement.getContext() == null)
+			// workaround bug ...
+			return 0;
+
+		// we haven't found the decay yet.
+		if (originalDecay == null)
+			originalDecay = interactionElement.getContext().getScaling().getDecay();
+
+		IDegreeOfInterest degreeOfInterest = interactionElement.getInterest();
+
 		if (degreeOfInterest != null) {
+			InteractionContextScaling scaling = (InteractionContextScaling) interactionElement.getContext()
+					.getScaling();
+
+			// if the method is an enclosing method.
+			if (enclosingMethods.contains(method)) {
+				// set a special decay.
+				scaling.setDecay(originalDecay / ENCLOSING_METHOD_DECAY_FACTOR);
+			} else { // otherwise, it's a non-enclosing method.
+				// use the original decay.
+				scaling.setDecay(originalDecay);
+			}
+
 			if (degreeOfInterest.getValue() > 0)
 				return degreeOfInterest.getValue();
 		}
 		return 0;
-	}
-
-	/**
-	 * Get DOI
-	 */
-	public static IDegreeOfInterest getDegreeOfInterest(IMethod method) {
-		IInteractionElement interactionElement = getInteractionElement(method);
-		if (interactionElement == null || interactionElement.getContext() == null) // workaround
-																					// bug
-																					// ...
-			return null;
-		return interactionElement.getInterest();
 	}
 
 	// The element in Mylyn

--- a/edu.cuny.hunter.log.evalution/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.log.evalution/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources;bundle-version="3.12.0",
  org.eclipse.core.runtime;bundle-version="3.13.0",
- edu.cuny.hunter.log.ui;bundle-version="1.0.0"
+ edu.cuny.hunter.log.ui;bundle-version="1.0.0",
+ org.eclipse.jdt.core;bundle-version="3.16.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: edu.cuny.citytech.refactoring.common.core,
  edu.cuny.hunter.log.core.analysis,


### PR DESCRIPTION
Possible fix for https://github.com/ponder-lab/Logging-Level-Evolution-Plugin/issues/217. This changes the decay rate *only* for *enclosing* methods.