### PR TITLE
Fix the issue that log invocation in switch statement and its case label mentions a log level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: java
-jdk: oraclejdk8
+jdk: openjdk11
 dist: trusty
 cache:
     apt: true

--- a/edu.cuny.hunter.log.core/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.log.core/META-INF/MANIFEST.MF
@@ -30,6 +30,8 @@ Import-Package: edu.cuny.citytech.refactoring.common.core,
  org.eclipse.text.edits,
  org.osgi.framework;version="1.8.0"
 Export-Package: edu.cuny.hunter.log.core.analysis,
+ edu.cuny.hunter.log.core.contributions,
+ edu.cuny.hunter.log.core.descriptors,
  edu.cuny.hunter.log.core.messages,
  edu.cuny.hunter.log.core.refactorings,
  edu.cuny.hunter.log.core.utils

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -77,10 +77,10 @@ public class LogAnalyzer extends ASTVisitor {
 	/**
 	 * A set of keywords in log messages for lowering log levels.
 	 */
-	private static final Set<String> KEYWORDS_IN_LOG_MESSAGES_FOR_LOWERING = Stream
-			.of("fail", "disable", "error", "exception", "collision", "reboot", "terminate", "throw", "should", "start",
-					"tried", "empty", "launch", "init", "does not", "doesn't", "stop", "shut", "run", "deprecate",
-					"kill", "finish", "ready", "wait", "dead", "alive", "creat")
+	private static final Set<String> KEYWORDS_IN_LOG_MESSAGES_FOR_LOWERING = Stream.of("fail", "disable", "error",
+			"exception", "collision", "reboot", "terminate", "throw", "should", "start", "tried", "empty", "launch",
+			"init", "does not", "doesn't", "stop", "shut", "run", "deprecate", "kill", "finish", "ready", "wait",
+			"dead", "alive", "creat", "debug", "info", "warn", "fatal", "severe", "config", "fine", "trace", "FYI")
 			.collect(Collectors.toSet());
 	/**
 	 * A set of keywords in log messages for raising log levels.

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -470,6 +470,7 @@ public class LogAnalyzer extends ASTVisitor {
 
 				// get the corresponding case label for the log invocation.
 				Set<Integer> positions = postionToSwitchCase.keySet();
+				// tmp is the max poisition before nodePosition
 				int tmp = 0;
 				for (int p : positions)
 					if (p < nodePosition && p >= tmp) {
@@ -480,13 +481,10 @@ public class LogAnalyzer extends ASTVisitor {
 				SwitchCase switchCase = postionToSwitchCase.get(tmp);
 
 				// check whether the case label contains the keywords
-				//for (Object e : switchCase.expressions())
-				String expression = switchCase.toString();
-				System.out.println(expression);
-					if (containingKeywords(switchCase.toString())) {
-						LOGGER.info("We meet a logging wrapping: \n" + node);
-						return true;
-					}
+				if (containingKeywords(switchCase.toString())) {
+					LOGGER.info("We meet a logging wrapping: \n" + node);
+					return true;
+				}
 				return false;
 			}
 			node = node.getParent();

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -22,11 +22,14 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SwitchCase;
+import org.eclipse.jdt.core.dom.SwitchStatement;
 import edu.cuny.hunter.log.core.messages.Messages;
 import edu.cuny.hunter.log.core.utils.LoggerNames;
 import edu.cuny.hunter.log.core.utils.Util;
@@ -186,10 +189,12 @@ public class LogAnalyzer extends ASTVisitor {
 
 		/**
 		 * Do not change a log level in a logging statement if there exists an immediate
-		 * if statement whose condition contains a log level.
+		 * if statement whose condition contains a log level or a case label mentioning
+		 * a log level.
 		 */
 		if (this.checkIfCondition) {
-			if (checkIfConditionHavingLevel(logInvocation.getExpression())) {
+			if (checkIfConditionHavingLevel(logInvocation.getExpression())
+					|| checkCaseHavingLevel(logInvocation.getExpression())) {
 				logInvocation.setAction(Action.NONE, null);
 				this.logInvsNotTransformedInIf.add(logInvocation);
 				return false;
@@ -433,11 +438,8 @@ public class LogAnalyzer extends ASTVisitor {
 	private static boolean checkIfConditionHavingLevel(ASTNode node) {
 		while (node != null) {
 			if (node instanceof IfStatement) {
-				String condition = ((IfStatement) node).getExpression().toString().toUpperCase();
-				if (condition.contains("CONFIG") || condition.contains("FINE") || condition.contains("FINER")
-						|| condition.contains("FINEST") || condition.contains("SEVERE") || condition.contains("WARN")
-						|| condition.contains("INFO") || condition.contains("FATAL") || condition.contains("ERROR")
-						|| condition.contains("DEBUG") || condition.contains("TRACE")) {
+				Expression condition = ((IfStatement) node).getExpression();
+				if (containingKeywords(condition)) {
 					LOGGER.info("We meet a logging wrapping: \n" + node);
 					return true;
 				}
@@ -445,6 +447,64 @@ public class LogAnalyzer extends ASTVisitor {
 			node = node.getParent();
 		}
 		return false;
+	}
+
+	/**
+	 * Check case label mentions log levels.
+	 */
+	private static boolean checkCaseHavingLevel(ASTNode node) {
+		int nodePosition = node.getStartPosition();
+		while (node != null) {
+			if (node instanceof SwitchStatement) {
+				SwitchStatement switchStatement = (SwitchStatement) node;
+
+				Map<Integer, SwitchCase> postionToSwitchCase = new HashMap<Integer, SwitchCase>();
+				// get a list of positions for switch cases
+				switchStatement.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(SwitchCase switchCase) {
+						postionToSwitchCase.put(switchCase.getStartPosition(), switchCase);
+						return true;
+					}
+				});
+
+				// get the corresponding case label for the log invocation.
+				Set<Integer> positions = postionToSwitchCase.keySet();
+				int tmp = 0;
+				for (int p : positions)
+					if (p < nodePosition && p >= tmp) {
+						tmp = p;
+					}
+				if (tmp == 0)
+					return false;
+				SwitchCase switchCase = postionToSwitchCase.get(tmp);
+
+				// check whether the case label contains the keywords
+				for (Object e : switchCase.expressions())
+					if (containingKeywords(e)) {
+						LOGGER.info("We meet a logging wrapping: \n" + node);
+						return true;
+					}
+				return false;
+			}
+			node = node.getParent();
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether if condition or case label contains a particular log level.
+	 */
+	private static boolean containingKeywords(Object expression) {
+		String label = expression.toString().toUpperCase();
+		if (label.contains("CONFIG") || label.contains("FINE") || label.contains("FINER") || label.contains("FINEST")
+				|| label.contains("SEVERE") || label.contains("WARN") || label.contains("INFO")
+				|| label.contains("FATAL") || label.contains("ERROR") || label.contains("DEBUG")
+				|| label.contains("TRACE"))
+			return true;
+		else
+			return false;
+
 	}
 
 	/**

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogAnalyzer.java
@@ -480,8 +480,10 @@ public class LogAnalyzer extends ASTVisitor {
 				SwitchCase switchCase = postionToSwitchCase.get(tmp);
 
 				// check whether the case label contains the keywords
-				for (Object e : switchCase.expressions())
-					if (containingKeywords(e)) {
+				//for (Object e : switchCase.expressions())
+				String expression = switchCase.toString();
+				System.out.println(expression);
+					if (containingKeywords(switchCase.toString())) {
 						LOGGER.info("We meet a logging wrapping: \n" + node);
 						return true;
 					}

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewr
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaStatusContext;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.RefactoringStatusContext;
-import org.eclipse.mylyn.context.core.IDegreeOfInterest;
 import org.eclipse.mylyn.internal.tasks.core.TaskList;
 import org.eclipse.mylyn.internal.tasks.ui.TasksUiPlugin;
 import org.osgi.framework.FrameworkUtil;
@@ -56,8 +55,6 @@ public class LogInvocation {
 	private Name replacedName;
 
 	private Name newTargetName;
-
-	private IDegreeOfInterest degreeOfInterest;
 
 	private final MethodInvocation logExpression;
 

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/analysis/LogInvocation.java
@@ -174,7 +174,7 @@ public class LogInvocation {
 				ASTRewrite astRewrite = rewrite.getASTRewrite();
 
 				// The methods (e.g., warning() -> critical()).
-				if (isLoggingLevelMethod(identifier)) {
+				if (Util.isLoggingLevelMethod(identifier)) {
 
 					SimpleName newMethodName = ast.newSimpleName(target);
 					astRewrite.replace(expression.getName(), newMethodName, null);
@@ -234,17 +234,6 @@ public class LogInvocation {
 	 */
 	private static boolean isLogMethod(String methodName) {
 		if (methodName.equals("log") || methodName.equals("logp") || methodName.equals("logrb"))
-			return true;
-		return false;
-	}
-
-	/**
-	 * Check whether the logging method contains logging level
-	 */
-	private static boolean isLoggingLevelMethod(String methodName) {
-		if (methodName.equals("config") || methodName.equals("fine") || methodName.equals("finer")
-				|| methodName.equals("finest") || methodName.equals("info") || methodName.equals("severe")
-				|| methodName.equals("warning"))
 			return true;
 		return false;
 	}

--- a/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
+++ b/edu.cuny.hunter.log.core/src/edu/cuny/hunter/log/core/utils/Util.java
@@ -1,6 +1,7 @@
 package edu.cuny.hunter.log.core.utils;
 
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -108,6 +109,17 @@ public final class Util {
 	}
 
 	/**
+	 * Check whether the logging method contains logging level
+	 */
+	public static boolean isLoggingLevelMethod(String methodName) {
+		if (methodName.equals("config") || methodName.equals("fine") || methodName.equals("finer")
+				|| methodName.equals("finest") || methodName.equals("info") || methodName.equals("severe")
+				|| methodName.equals("warning"))
+			return true;
+		return false;
+	}
+
+	/**
 	 * Clear the active task context.
 	 * 
 	 * @throws NonActiveMylynTaskException
@@ -116,10 +128,25 @@ public final class Util {
 		MylynGitPredictionProvider.clearTaskContext();
 	}
 
+	@SuppressWarnings("unchecked")
 	public static boolean isLogMessageWithKeywords(MethodInvocation node, Set<String> keyWordsInLogMessages) {
-		String logExpression = node.toString().toLowerCase();
+
+		String identifier = node.getName().getIdentifier();
+		String logMessage = "";
+
+		List<Expression> arguments = new LinkedList<Expression>();
+		arguments.addAll(node.arguments());
+
+		// log(Level.INFO, "...");
+		if (!Util.isLoggingLevelMethod(identifier)) {
+			arguments.remove(0);
+		}
+
+		for (Expression argument : arguments)
+			logMessage += argument.toString().toLowerCase();
+
 		for (String key : keyWordsInLogMessages) {
-			if (logExpression.contains(key.toLowerCase()))
+			if (logMessage.contains(key.toLowerCase()))
 				return true;
 		}
 		return false;

--- a/edu.cuny.hunter.log.evalution/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.log.evalution/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package: edu.cuny.citytech.refactoring.common.core,
 Bundle-ClassPath: lib/commons-csv-1.1.jar,
  .
 Automatic-Module-Name: edu.cuny.hunter.log.evaluation
+Export-Package: org.apache.commons.csv

--- a/edu.cuny.hunter.log.tests/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.log.tests/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  edu.cuny.hunter.log.core,
  org.eclipse.jdt.ui.tests.refactoring;bundle-version="3.13.200"
 Automatic-Module-Name: edu.cuny.hunter.log.tests
+Export-Package: edu.cuny.hunter.log.ui.tests

--- a/edu.cuny.hunter.log.ui/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.log.ui/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.ui,
  edu.cuny.citytech.refactoring.common.core;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.jdt.internal.core.manipulation
-Export-Package: edu.cuny.hunter.log.ui.messages,
+Export-Package: edu.cuny.hunter.log.ui.handlers,
+ edu.cuny.hunter.log.ui.messages,
  edu.cuny.hunter.log.ui.wizards
 Automatic-Module-Name: edu.cuny.hunter.log.ui

--- a/edu.cuny.hunter.log.ui/src/edu/cuny/hunter/log/ui/wizards/LogWizard.java
+++ b/edu.cuny.hunter.log.ui/src/edu/cuny/hunter/log/ui/wizards/LogWizard.java
@@ -152,7 +152,7 @@ public class LogWizard extends RefactoringWizard {
 					NOT_RAISE_LOG_LEVEL_KEY_WORDS, this.getProcessor()::setNotRaiseLogLevelWithoutKeyWords, result,
 					SWT.CHECK);
 
-			this.addBooleanButton("Do not change a log level if its if statement condition contains a log level.",
+			this.addBooleanButton("Do not change a log level if its if statement condition/case label contains a log level.",
 					CHECK_IF_CONDITION, this.getProcessor()::setCheckIfCondition, result, SWT.CHECK);
 
 			Label separator3 = new Label(result, SWT.SEPARATOR | SWT.SHADOW_OUT | SWT.HORIZONTAL);

--- a/edu.cuny.hunter.log.ui/src/edu/cuny/hunter/log/ui/wizards/LogWizard.java
+++ b/edu.cuny.hunter.log.ui/src/edu/cuny/hunter/log/ui/wizards/LogWizard.java
@@ -6,7 +6,6 @@ import java.util.function.Consumer;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.internal.ui.refactoring.RefactoringMessages;
 import org.eclipse.jdt.internal.ui.refactoring.actions.RefactoringStarter;
 import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;

--- a/edu.cuny.hunter.mylyngit.evaluation/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.mylyngit.evaluation/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.jdt.ui
 Automatic-Module-Name: edu.cuny.hunter.mylyngit.eval
+Export-Package: org.apache.commons.csv

--- a/edu.cuny.hunter.mylyngit.tests/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.mylyngit.tests/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jgit;bundle-version="5.1.0",
  org.junit;bundle-version="4.12.0"
 Import-Package: edu.cuny.hunter.mylyngit.core.analysis
+Export-Package: edu.cuny.hunter.mylyngit.tests


### PR DESCRIPTION
We noticed that there are some log invocations like:
```
     case DEBUG:
-        impl.log(Level.FINE, line);
+        impl.log(Level.FINER, line);
        break;
```

For these log invocations, they should not be transformed.