### PR TITLE
Fix candidate number counting in EvaluationHandler

### DIFF
--- a/edu.cuny.hunter.log.evalution/src/edu/cuny/hunter/log/evaluation/handlers/EvaluationHandler.java
+++ b/edu.cuny.hunter.log.evalution/src/edu/cuny/hunter/log/evaluation/handlers/EvaluationHandler.java
@@ -775,7 +775,7 @@ public class EvaluationHandler extends AbstractHandler {
 		// Set of candidate log invocations.
 		Set<LogInvocation> candidates = new HashSet<LogInvocation>();
 		if (!this.isUseLogCategory() && !this.isUseLogCategoryWithConfig())
-			candidates.addAll(candidates);
+			candidates.addAll(logInvocationSet);
 
 		if (this.isUseLogCategoryWithConfig()) {
 			for (LogInvocation inv : logInvocationSet)


### PR DESCRIPTION
If we don't use any log category, the candidate number is always 0 due to this bug. 